### PR TITLE
Support for @PersistJobDataAfterExecution and @DisallowConcurrentExecution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 3.2.? (2020-02-??)
+
+* [new] Task now honor @DisallowConcurrentExecution and @PersistJobDataAfterExecution as if they were a pure Quartz Job
+
 # Version 3.2.0 (2019-12-19)
 
 * [chg] Updated for SeedStack 19.11

--- a/src/main/java/org/seedstack/scheduler/internal/GuiceTaskFactory.java
+++ b/src/main/java/org/seedstack/scheduler/internal/GuiceTaskFactory.java
@@ -36,8 +36,9 @@ class GuiceTaskFactory implements JobFactory {
         // create new Job
         String taskClassName = bundle.getJobDetail().getKey().getGroup();
         try {
-            return new TaskDelegateJob(
-                    injector.getInstance((Class<? extends Task>) Class.forName(taskClassName)));
+            return JobDelegateFactory
+                    .buildJobWrapper(injector.getInstance((Class<? extends Task>) Class.forName(taskClassName)));
+
         } catch (Exception ex) {
             throw SeedException.wrap(ex, SchedulerErrorCode.FAILED_TO_INSTANTIATE_TASK)
                     .put("taskClass", taskClassName);

--- a/src/main/java/org/seedstack/scheduler/internal/JobDelegateFactory.java
+++ b/src/main/java/org/seedstack/scheduler/internal/JobDelegateFactory.java
@@ -11,6 +11,7 @@ import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.PersistJobDataAfterExecution;
 import org.seedstack.scheduler.Task;
+import org.seedstack.seed.SeedException;
 
 class JobDelegateFactory {
 
@@ -19,14 +20,11 @@ class JobDelegateFactory {
     }
 
     static Job buildJobWrapper(Task task) {
-
         try {
             return computeDelegateClass(task.getClass()).getConstructor(Task.class).newInstance(task);
         } catch (Exception e) {
-            // TODO: Put a proper logger / error handler here
-            throw new RuntimeException(e);
+            throw SeedException.wrap(e, SchedulerErrorCode.CANNOT_INITIALIZE_TASK);
         }
-
     }
 
     static Class<? extends TaskDelegateJob> computeDelegateClass(Class<? extends Task> taskClazz) {

--- a/src/main/java/org/seedstack/scheduler/internal/JobDelegateFactory.java
+++ b/src/main/java/org/seedstack/scheduler/internal/JobDelegateFactory.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.seedstack.scheduler.internal;
 
 import org.quartz.DisallowConcurrentExecution;

--- a/src/main/java/org/seedstack/scheduler/internal/JobDelegateFactory.java
+++ b/src/main/java/org/seedstack/scheduler/internal/JobDelegateFactory.java
@@ -1,0 +1,42 @@
+package org.seedstack.scheduler.internal;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.PersistJobDataAfterExecution;
+import org.seedstack.scheduler.Task;
+
+class JobDelegateFactory {
+
+    private JobDelegateFactory() {
+        // No Instances
+    }
+
+    static Job buildJobWrapper(Task task) {
+
+        try {
+            return computeDelegateClass(task.getClass()).getConstructor(Task.class).newInstance(task);
+        } catch (Exception e) {
+            // TODO: Put a proper logger / error handler here
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    static Class<? extends TaskDelegateJob> computeDelegateClass(Class<? extends Task> taskClazz) {
+
+        boolean nonConcurrentExecution = taskClazz.getAnnotation(DisallowConcurrentExecution.class) != null;
+        boolean persistDataAfterExecution = taskClazz.getAnnotation(PersistJobDataAfterExecution.class) != null;
+
+        if (!nonConcurrentExecution && !persistDataAfterExecution) {
+            return TaskDelegateJob.class;
+        } else if (nonConcurrentExecution && persistDataAfterExecution) {
+            return NonConcurrentPersistentDataTaskDelegateJob.class;
+        } else if (nonConcurrentExecution && !persistDataAfterExecution) {
+            return NonConcurrentTaskDelegateJob.class;
+        } else {
+            return PersistentDataTaskDelegateJob.class;
+        }
+
+    }
+
+}

--- a/src/main/java/org/seedstack/scheduler/internal/NonConcurrentPersistentDataTaskDelegateJob.java
+++ b/src/main/java/org/seedstack/scheduler/internal/NonConcurrentPersistentDataTaskDelegateJob.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.seedstack.scheduler.internal;
 
 import org.quartz.DisallowConcurrentExecution;

--- a/src/main/java/org/seedstack/scheduler/internal/NonConcurrentPersistentDataTaskDelegateJob.java
+++ b/src/main/java/org/seedstack/scheduler/internal/NonConcurrentPersistentDataTaskDelegateJob.java
@@ -1,0 +1,15 @@
+package org.seedstack.scheduler.internal;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.PersistJobDataAfterExecution;
+import org.seedstack.scheduler.Task;
+
+@DisallowConcurrentExecution
+@PersistJobDataAfterExecution
+class NonConcurrentPersistentDataTaskDelegateJob extends TaskDelegateJob {
+
+    public NonConcurrentPersistentDataTaskDelegateJob(Task task) {
+        super(task);
+    }
+
+}

--- a/src/main/java/org/seedstack/scheduler/internal/NonConcurrentTaskDelegateJob.java
+++ b/src/main/java/org/seedstack/scheduler/internal/NonConcurrentTaskDelegateJob.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.seedstack.scheduler.internal;
 
 import org.quartz.DisallowConcurrentExecution;

--- a/src/main/java/org/seedstack/scheduler/internal/NonConcurrentTaskDelegateJob.java
+++ b/src/main/java/org/seedstack/scheduler/internal/NonConcurrentTaskDelegateJob.java
@@ -1,0 +1,13 @@
+package org.seedstack.scheduler.internal;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.seedstack.scheduler.Task;
+
+@DisallowConcurrentExecution
+class NonConcurrentTaskDelegateJob extends TaskDelegateJob {
+
+    public NonConcurrentTaskDelegateJob(Task task) {
+        super(task);
+    }
+
+}

--- a/src/main/java/org/seedstack/scheduler/internal/PersistentDataTaskDelegateJob.java
+++ b/src/main/java/org/seedstack/scheduler/internal/PersistentDataTaskDelegateJob.java
@@ -1,0 +1,13 @@
+package org.seedstack.scheduler.internal;
+
+import org.quartz.PersistJobDataAfterExecution;
+import org.seedstack.scheduler.Task;
+
+@PersistJobDataAfterExecution
+class PersistentDataTaskDelegateJob extends TaskDelegateJob {
+
+    public PersistentDataTaskDelegateJob(Task task) {
+        super(task);
+    }
+
+}

--- a/src/main/java/org/seedstack/scheduler/internal/PersistentDataTaskDelegateJob.java
+++ b/src/main/java/org/seedstack/scheduler/internal/PersistentDataTaskDelegateJob.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.seedstack.scheduler.internal;
 
 import org.quartz.PersistJobDataAfterExecution;

--- a/src/main/java/org/seedstack/scheduler/internal/ScheduledTaskBuilderImpl.java
+++ b/src/main/java/org/seedstack/scheduler/internal/ScheduledTaskBuilderImpl.java
@@ -113,7 +113,8 @@ class ScheduledTaskBuilderImpl implements ScheduledTaskBuilder {
     private Class<? extends Task> taskClass;
 
     ScheduledTaskBuilderImpl(final Class<? extends Task> taskClass, Scheduler scheduler, Application application) {
-        this.jobClass = TaskDelegateJob.class;
+
+        this.jobClass = JobDelegateFactory.computeDelegateClass(taskClass);
         this.scheduler = scheduler;
         this.taskClass = taskClass;
 

--- a/src/main/java/org/seedstack/scheduler/internal/SchedulerErrorCode.java
+++ b/src/main/java/org/seedstack/scheduler/internal/SchedulerErrorCode.java
@@ -10,6 +10,7 @@ package org.seedstack.scheduler.internal;
 import org.seedstack.shed.exception.ErrorCode;
 
 enum SchedulerErrorCode implements ErrorCode {
+	CANNOT_INITIALIZE_TASK,
     EXCEPTION_IN_LISTENER,
     FAILED_TO_INSTANTIATE_TASK,
     IMPOSSIBLE_TO_USE_CRON_AND_TRIGGER,

--- a/src/main/java/org/seedstack/scheduler/internal/TaskDelegateJob.java
+++ b/src/main/java/org/seedstack/scheduler/internal/TaskDelegateJob.java
@@ -21,7 +21,7 @@ import org.seedstack.scheduler.Task;
 class TaskDelegateJob implements Job {
     private final Task task;
 
-    TaskDelegateJob(Task task) {
+    public TaskDelegateJob(Task task) {
         this.task = task;
     }
 

--- a/src/main/resources/org/seedstack/scheduler/internal/SchedulerErrorCode.properties
+++ b/src/main/resources/org/seedstack/scheduler/internal/SchedulerErrorCode.properties
@@ -6,6 +6,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
+CANNOT_INITIALIZE_TASK="Task cannot be wrapped as a Quartz Job"
+CANNOT_INITIALIZE_TASK.description="Check inner exception for more information"
 EXCEPTION_IN_LISTENER=An exception occurred in method ${method} of listener '${listenerClass}'.
 EXCEPTION_IN_LISTENER.fix=Check your listener code to avoid throwing any exception. Use a try/catch block if necessary.
 FAILED_TO_INSTANTIATE_TASK=Failed to instantiate the task class '${taskClass}'.
@@ -24,4 +26,4 @@ TRIGGER_AND_JOB_NAME_SHOULD_BE_UNIQUE.fix=If you want to schedule multiple tasks
 UNABLE_TO_UNWRAP=Class '${class}' cannot be unwrapped.
 UNABLE_TO_UNWRAP.fix=Only 'JobExecutionContext' class can be unwrapped.
 UNRECOGNIZED_TRIGGER=Could not find a trigger with name '${triggerName}' and group '${triggerGroup}'.
-UNRECOGNIZED_TRIGGER.fix=Ensure that you have created the trigger previosly.
+UNRECOGNIZED_TRIGGER.fix=Ensure that you have created the trigger previously.

--- a/src/test/java/org/seedstack/scheduler/ConcurrentSchedulingIT.java
+++ b/src/test/java/org/seedstack/scheduler/ConcurrentSchedulingIT.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.seedstack.scheduler;
 
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/org/seedstack/scheduler/ConcurrentSchedulingIT.java
+++ b/src/test/java/org/seedstack/scheduler/ConcurrentSchedulingIT.java
@@ -1,0 +1,50 @@
+package org.seedstack.scheduler;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.TriggerBuilder;
+import org.seedstack.scheduler.fixtures.NonConcurrentTask;
+import org.seedstack.seed.testing.junit4.SeedITRunner;
+
+@RunWith(SeedITRunner.class)
+public class ConcurrentSchedulingIT {
+
+    @Inject
+    private ScheduledTasks scheduledTasks;
+
+    /***
+     * SCENARIO
+     * 
+     * Trigger should have been fired 9 times.
+     * <p>
+     * The task has a 2 second delay, so it will miss 4 Triggers (Odd Seconds)
+     * </p>
+     * Due to Misfire policy, missed triggers will be ignored and won't be fired
+     */
+    @Test
+    public void testNonConcurrentExecutions() throws Exception {
+
+        NonConcurrentTask.executionCount.set(0);
+
+        Assertions.assertThat(NonConcurrentTask.executionCount.get()).isEqualTo(0);
+
+        scheduledTasks.scheduledTask(NonConcurrentTask.class)
+                .withTrigger(TriggerBuilder.newTrigger().startNow()
+                        .withSchedule(SimpleScheduleBuilder.repeatSecondlyForTotalCount(9)
+                                .withMisfireHandlingInstructionNextWithRemainingCount())
+                        .build())
+                .schedule();
+
+        TimeUnit.SECONDS.sleep(9);
+
+        Assertions.assertThat(NonConcurrentTask.executionCount.get()).isEqualTo(5);
+
+    }
+
+}

--- a/src/test/java/org/seedstack/scheduler/fixtures/NonConcurrentTask.java
+++ b/src/test/java/org/seedstack/scheduler/fixtures/NonConcurrentTask.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.seedstack.scheduler.fixtures;
 
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/org/seedstack/scheduler/fixtures/NonConcurrentTask.java
+++ b/src/test/java/org/seedstack/scheduler/fixtures/NonConcurrentTask.java
@@ -1,0 +1,21 @@
+package org.seedstack.scheduler.fixtures;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.seedstack.scheduler.SchedulingContext;
+import org.seedstack.scheduler.Task;
+
+@DisallowConcurrentExecution
+public class NonConcurrentTask implements Task {
+
+    public static AtomicInteger executionCount = new AtomicInteger();
+
+    @Override
+    public void execute(SchedulingContext sc) throws Exception {
+        executionCount.incrementAndGet();
+        TimeUnit.SECONDS.sleep(2);
+    }
+
+}

--- a/src/test/java/org/seedstack/scheduler/fixtures/TimedDurableDataTask.java
+++ b/src/test/java/org/seedstack/scheduler/fixtures/TimedDurableDataTask.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.scheduler.fixtures;
+
+import java.util.Map;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.PersistJobDataAfterExecution;
+import org.seedstack.scheduler.SchedulingContext;
+import org.seedstack.scheduler.Task;
+
+@DisallowConcurrentExecution
+@PersistJobDataAfterExecution
+public class TimedDurableDataTask implements Task {
+
+	public static int fireCount = 0;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void execute(SchedulingContext sc) throws Exception {
+
+		Integer count = ((Map<String, Integer>) sc.getDataMap()).getOrDefault("count", 0);
+		((Map<String, Integer>) sc.getDataMap()).put("count", count + 1);
+
+		fireCount = ((Map<String, Integer>) sc.getDataMap()).getOrDefault("count", 0);
+
+	}
+
+}

--- a/src/test/java/org/seedstack/scheduler/fixtures/TimedNonDurableDataTask.java
+++ b/src/test/java/org/seedstack/scheduler/fixtures/TimedNonDurableDataTask.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2013-2019, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.scheduler.fixtures;
+
+import java.util.Map;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.seedstack.scheduler.SchedulingContext;
+import org.seedstack.scheduler.Task;
+
+@DisallowConcurrentExecution
+public class TimedNonDurableDataTask implements Task {
+
+	public static int fireCount = 0;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void execute(SchedulingContext sc) throws Exception {
+
+		Integer count = ((Map<String, Integer>) sc.getDataMap()).getOrDefault("count", 0);
+		((Map<String, Integer>) sc.getDataMap()).put("count", count + 1);
+
+		fireCount = ((Map<String, Integer>) sc.getDataMap()).getOrDefault("count", 0);
+
+	}
+
+}


### PR DESCRIPTION
Due to Task Wrapper, Quartz was unable to read those two annotations.


This PR addresses that limitation, creating a wrapper for every combination of those annotations, and extending the wrapper accordingly

---
Note: There's still some testing to be done, and a TODO with regard to exception handling
